### PR TITLE
+rel to absURL for better? refresh on change

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
   <title>{{ block "title" . }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ block "meta_tags" . }}{{end}}
-  <link rel="icon" href="{{ "favicon-32x32.png" | relURL }}">
+  <link rel="icon" href="{{ .Site.Params.logo.favicon | absURL }}">
 
   <!-- CSS-->
   {{ if .Site.IsServer }}


### PR DESCRIPTION
+ favicon file name is now a variable that can be found in the *.toml
+ relURL to absURL means the absolute url get placed in the html - does this help with favicon refresh ? i dunno